### PR TITLE
fix: make so rest api calls are also available under /redAdmin

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,6 +94,7 @@ module.exports = function(app) {
       app.get('/redAdmin', (req, res) => {
         res.redirect(redSettings.httpAdminRoot)
       })
+      app.use(redSettings.httpAdminRoot, RED.httpNode);
     }
 
     unsubscribes.push(RED.stop)


### PR DESCRIPTION
Some nodes assume the api will be available there even when the api root is different

This is specifically causing issues with Victron's node-red palette and thew new Virtual Devices.