### PR TITLE
fix node-red debug log timestamp to ISO8601

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,19 @@ module.exports = function(app) {
     redSettings = {
        
       userDir: app.config.configPath + '/red',
-      logging: {'console': { level: theOptions.logging || 'info'}},
+      logging: {
+        console: {
+          level: theOptions.logging || 'info',
+          handler: function() {
+            const levelNames = { 10: 'fatal', 20: 'error', 30: 'warn', 40: 'info', 50: 'debug', 60: 'trace', 98: 'audit', 99: 'metric' }
+            return function(msg) {
+              const ts = new Date().toISOString()
+              const level = levelNames[msg.level] || 'info'
+              console.log(`${ts} node-red [${level}] ${msg.msg}`)
+            }
+          }
+        }
+      },
       credentialSecret: 'jkhdfshjkfdskjhfsjfsdkjhsfdjkfsd',
       functionGlobalContext: {
         streambundle: app.streambundle,


### PR DESCRIPTION
in reference to: https://github.com/SignalK/signalk-server/issues/2139

# Issue: Node-RED logs use non-ISO 8601 timestamp format

## Problem

Node-RED embedded in the signalk-node-red plugin outputs logs with timestamps in a non-standard format (`7 Dec 15:19:17`) instead of ISO 8601 format (`2025-12-07T15:19:17.000Z`).

This causes:

1. **Inconsistent log format**: Signal K debug logs use ISO 8601, but Node-RED logs use a different format
2. **Harder to parse**: Non-standard format is difficult to parse programmatically
3. **Ambiguous**: No year, abbreviated month name varies by locale

### Example log output (before fix)

```
Dec 07 15:34:54 pi5 signalk-server[1099239]: Welcome to Node-RED
Dec 07 15:34:54 pi5 signalk-server[1099239]: ===================
Dec 07 15:34:54 pi5 signalk-server[1099239]: 7 Dec 15:34:54 - [info] Node-RED version: v4.1.1
Dec 07 15:34:54 pi5 signalk-server[1099239]: 7 Dec 15:34:54 - [info] Node.js  version: v22.21.0
Dec 07 15:34:54 pi5 signalk-server[1099239]: 7 Dec 15:34:54 - [info] Linux 6.12.47+rpt-rpi-2712 arm64 LE
Dec 07 15:34:54 pi5 signalk-server[1099239]: 7 Dec 15:34:54 - [info] Loading palette nodes
Dec 07 15:34:55 pi5 signalk-server[1099239]: 7 Dec 15:34:55 - [info] node-red-contrib-telegrambot version: v16.4.0
Dec 07 15:34:55 pi5 signalk-server[1099239]: 7 Dec 15:34:55 - [info] Dashboard version 3.6.6 started at /plugins/signalk-node-red/redApi/ui
Dec 07 15:34:55 pi5 signalk-server[1099239]: 7 Dec 15:34:55 - [info] Context store  : 'default' [module=memory]
Dec 07 15:34:55 pi5 signalk-server[1099239]: 7 Dec 15:34:55 - [info] User directory : /home/dirk/.signalk/red
```

### Example log output (after fix)

```
Dec 07 15:45:57 pi5 signalk-server[1099829]: Welcome to Node-RED
Dec 07 15:45:57 pi5 signalk-server[1099829]: ===================
Dec 07 15:45:57 pi5 signalk-server[1099829]: 2025-12-07T03:45:57.302Z node-red [info] Node-RED version: v4.1.1
Dec 07 15:45:57 pi5 signalk-server[1099829]: 2025-12-07T03:45:57.303Z node-red [info] Node.js  version: v22.21.0
Dec 07 15:45:57 pi5 signalk-server[1099829]: 2025-12-07T03:45:57.303Z node-red [info] Linux 6.12.47+rpt-rpi-2712 arm64 LE
Dec 07 15:45:57 pi5 signalk-server[1099829]: 2025-12-07T03:45:57.411Z node-red [info] Loading palette nodes
Dec 07 15:45:58 pi5 signalk-server[1099829]: 2025-12-07T03:45:58.168Z node-red [info] node-red-contrib-telegrambot version: v16.4.0
Dec 07 15:45:58 pi5 signalk-server[1099829]: 2025-12-07T03:45:58.230Z node-red [info] Dashboard version 3.6.6 started at /plugins/signalk-node-red/redApi/ui
Dec 07 15:45:58 pi5 signalk-server[1099829]: 2025-12-07T03:45:58.347Z node-red [info] Context store  : 'default' [module=memory]
Dec 07 15:45:58 pi5 signalk-server[1099829]: 2025-12-07T03:45:58.348Z node-red [info] User directory : /home/dirk/.signalk/red

```

## Root Cause

In `signalk-node-red/index.js`, the Node-RED logging configuration only specifies the log level, using Node-RED's default log handler which formats timestamps as `D MMM HH:mm:ss`:

```javascript
// Line 39 (before)
logging: {'console': { level: theOptions.logging || 'info'}},
```

## Solution

Replace the default logging configuration with a custom handler that uses ISO 8601 timestamps:

```javascript
// Line 39-51 (after)
logging: {
  console: {
    level: theOptions.logging || 'info',
    handler: function() {
      const levelNames = { 10: 'fatal', 20: 'error', 30: 'warn', 40: 'info', 50: 'debug', 60: 'trace', 98: 'audit', 99: 'metric' }
      return function(msg) {
        const ts = new Date().toISOString()
        const level = levelNames[msg.level] || 'info'
        console.log(`${ts} node-red [${level}] ${msg.msg}`)
      }
    }
  }
},
```

## Files modified

- `signalk-node-red/index.js` - lines 39-51

## Node-RED logging levels

| Level | Name   |
| ----- | ------ |
| 10    | fatal  |
| 20    | error  |
| 30    | warn   |
| 40    | info   |
| 50    | debug  |
| 60    | trace  |
| 98    | audit  |
| 99    | metric |

## Testing

1. Start Signal K server with the signalk-node-red plugin enabled
2. Check system logs (`journalctl -u signalk-server`) or console output
3. Verify Node-RED messages now use ISO 8601 format: `2025-12-07T15:19:17.000Z node-red [info] ...`

## Related

- Signal K server issue #2139
- Node-RED logging documentation: https://nodered.org/docs/user-guide/runtime/logging