### PR TITLE
Fix AggregateError crashes on Node.js 20+ caused by Happy Eyeballs (autoSelectFamily)

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,21 @@
  * limitations under the License.
  */
 
+/**
+ * Workaround for Node.js 20+ "Happy Eyeballs" (RFC 6555) causing AggregateError
+ * in libraries using @cypress/request (e.g., node-telegram-bot-api).
+ *
+ * Node.js 20+ enables autoSelectFamily by default, which tries IPv4 and IPv6
+ * simultaneously. When connections fail, it throws AggregateError which older
+ * HTTP libraries don't handle properly.
+ *
+ * See: https://github.com/yagop/node-telegram-bot-api/issues/1193
+ *      https://github.com/nodejs/node/pull/46790
+ */
+const net = require('net')
+if (typeof net.setDefaultAutoSelectFamily === 'function') {
+  net.setDefaultAutoSelectFamily(false)
+}
 
 const RED = require("node-red")
 const compareVersions = require('compare-versions')


### PR DESCRIPTION
## Summary

- Add workaround for Node.js 20+ "Happy Eyeballs" (RFC 6555) causing `AggregateError` in HTTP libraries

## Problem

Node.js 20+ enables `autoSelectFamily` by default, which implements RFC 6555 "Happy Eyeballs" - attempting IPv4 and IPv6 connections simultaneously. When both connection attempts fail, Node.js throws an `AggregateError`.

Libraries using `@cypress/request` (including `node-telegram-bot-api` used by `node-red-contrib-telegrambot`) don't handle `AggregateError` properly, causing unhandled exceptions and plugin crashes.

Example error:

```
AggregateError
    at internalConnectMultiple (node:net:1121:18)
    at afterConnectMultiple (node:net:1688:7)
```

## Solution

Disable `autoSelectFamily` at plugin initialization by calling `net.setDefaultAutoSelectFamily(false)`. This is placed at the very top of `index.js` before any dependencies are loaded, ensuring it applies globally to all network connections.

## References

- Upstream issue: [https://github.com/yagop/node-telegram-bot-api/issues/1193](https://github.com/yagop/node-telegram-bot-api/issues/1193)
- Node.js PR introducing the change: [https://github.com/nodejs/node/pull/46790](https://github.com/nodejs/node/pull/46790)

## Testing

Tested on SignalK server running Node.js v24.13.0 with `node-red-contrib-telegrambot`. Before the fix, continuous `AggregateError` crashes occurred. After the fix, no errors and stable operation.