### PR TITLE
fix: correct 'falal' typo to 'fatal' in logging config

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,7 +208,7 @@ module.exports = function(app) {
       logging: {
         type: 'string',
         title: 'Logging',
-        enum: [ 'falal', 'error', 'warn', 'info', 'debug', 'trace' ],
+        enum: [ 'fatal', 'error', 'warn', 'info', 'debug', 'trace' ],
         default: 'info'
       },
       requires: {


### PR DESCRIPTION
## Summary
Fixes a typo in the logging level dropdown where 'fatal' was misspelled as 'falal'.

## Related Issue
Fixes #60

## Changes
- Changed `'falal'` to `'fatal'` in the logging enum options

## Screenshot
The dropdown under Plugin Config > Logging now correctly shows 'fatal' instead of 'falal'.