### PR TITLE
feat: add Victron D-Bus address setting for remote GX devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,9 @@ See https://github.com/SignalK/node-red-embedded for available Nodes.
 You can access the node-red Admin console by navigating to Webapps on the node server admin console, or use a direct url like http://localhost:3000/plugins/signalk-node-red/redAdmin/
 
 If you install node red dashboard, then the url for the dashboard will be we be http://localhost:3000/plugins/signalk-node-red/redApi/ui/
+
+## Using the Victron nodes (node-red-contrib-victron) with a remote GX device
+
+The [node-red-contrib-victron](https://github.com/victronenergy/node-red-contrib-victron) nodes connect to the Victron D-Bus. When Signal K does not run on the GX device itself (for example when it runs in a container or on a separate machine), set the **Victron D-Bus Address** in the plugin settings to `<gx-address>:78`, e.g. `venus.local:78` or `192.168.1.4:78`.
+
+This requires "Insecure D-Bus over TCP" to be enabled on the GX device (`Settings → Services`, or `/Settings/Services/InsecureDbusOverTcp = 1`). The address must be in plain `host:port` form. Changing the value after the Victron nodes have connected requires a server restart to take effect.

--- a/index.js
+++ b/index.js
@@ -45,6 +45,16 @@ module.exports = function(app) {
   plugin.description = "Embeds node red in signalk node server";
 
   plugin.start = function(theOptions) {
+    if ( theOptions.victronDbusAddress && theOptions.victronDbusAddress.trim().length > 0 ) {
+      const victronDbusAddress = theOptions.victronDbusAddress.trim()
+      if ( /^[^:\s]+:\d+$/.test(victronDbusAddress) ) {
+        process.env.NODE_RED_DBUS_ADDRESS = victronDbusAddress
+      } else {
+        app.error(`invalid Victron D-Bus Address '${victronDbusAddress}', expected host:port, e.g. venus.local:78`)
+        app.setPluginError(`invalid Victron D-Bus Address '${victronDbusAddress}', expected host:port, e.g. venus.local:78`)
+      }
+    }
+
     redSettings = {
        
       userDir: app.config.configPath + '/red',
@@ -257,6 +267,11 @@ module.exports = function(app) {
         items: {
           type: 'string'
         }
+      },
+      victronDbusAddress: {
+        type: 'string',
+        title: 'Victron D-Bus Address (host:port)',
+        description: 'For node-red-contrib-victron: connect to a GX device over TCP instead of the local D-Bus, e.g. venus.local:78 or 192.168.1.4:78. Needed when Signal K does not run on the GX device itself, e.g. in a container. Requires "Insecure D-Bus over TCP" to be enabled on the GX device. Changing the value requires a server restart to take effect.'
       },
       settings: {
         title: 'Node Red Settings',


### PR DESCRIPTION
When Signal K runs in a container (or anywhere that is not the GX device itself), the node-red-contrib-victron nodes can only reach the Victron D-Bus via the `NODE_RED_DBUS_ADDRESS` environment variable. Getting an environment variable into the embedded Node-RED is awkward in that setup — it has to be threaded through docker-compose or the systemd unit into the server process, and users keep rediscovering this the hard way (most recently on Discord).

Since Node-RED runs in-process, the plugin can set the variable itself. I added a "Victron D-Bus Address (host:port)" plugin setting that exports `NODE_RED_DBUS_ADDRESS` before `RED.init`, so the option is visible and configurable in the admin UI for every runtime — container, compose, bare metal.

Details:

- The value is only exported when set and valid; a blank or absent setting leaves an externally provided `NODE_RED_DBUS_ADDRESS` untouched, so existing setups keep working unchanged.
- The value is validated as plain `host:port`. The victron nodes split the variable on `:` and expect exactly two parts — anything else (e.g. a full `tcp:host=...,port=...` D-Bus address string) makes them silently fall back to the local bus. Invalid values raise a plugin error in the admin UI instead of failing silently.
- The victron config node reads the variable at deploy time and caches its client in a module-global, so changing the address after the first connect needs a server restart; the setting description points this out.
- Added a README section documenting the remote-GX setup, including the required "Insecure D-Bus over TCP" setting on the GX device.

Tested with harness scripts that load the plugin directly: the env var is exported (trimmed) before `RED.init` is called; blank, absent and invalid values do not touch an externally set variable; and the plugin starts and stops cleanly with the option set against a real node-red instance.